### PR TITLE
Fix the code after API changes in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "readchar",
-  "lief",
-  "dataclasses-struct",
+  "readchar==4.2.1",
+  "lief==0.17.0",
+  "dataclasses-struct==1.4.0",
 ]
 
 [project.urls]

--- a/tinyrv/user.py
+++ b/tinyrv/user.py
@@ -31,7 +31,7 @@ def pack_args(args, xlen=32, sp=0x80000000):
     for o in offsets[:-1]: ptrs.append(struct.pack(ptr_fmt, sp+len(strings)*ptr_bytes+o+padding))
     return sp-ptr_bytes, struct.pack(ptr_fmt, len(strings)) + b''.join(ptrs+([b'\0']*padding)+strings)
 
-@dcs.dataclass()
+@dcs.dataclass_struct(size="std", byteorder="little")
 class kernel_stat2:
     st_dev:     dcs.U64 = 24
     st_ino:     dcs.U64 = 3
@@ -55,7 +55,7 @@ class elf_runner(sim):
     def __init__(self, elf_file, args=[], trace=False, trap_misaligned=False):
         elf = lief.parse(elf_file)
         assert elf.header.machine_type == lief.ELF.ARCH.RISCV
-        super().__init__(xlen=32 if elf.header.identity_class == lief.ELF.ELF_CLASS.CLASS32 else 64, trap_misaligned=trap_misaligned)
+        super().__init__(xlen=32 if elf.header.identity_class == lief.ELF.Header.CLASS.ELF32 else 64, trap_misaligned=trap_misaligned)
         self.elf_file, self.elf, self.trace = elf_file, elf, trace
         load_elf(self, self.elf, trace=trace)
         struct.pack_into('6IQ', *self.page_and_offset(0x1000),  # SAIL-style barebones bootloader


### PR DESCRIPTION
The project has loose depedencies, so any change to the API of the used libraries can easily break the execution of the code. Fix it by:

First, the latest dataclasses_struct requires '@dcs.dataclass_struct' instead of used '@dcs.dataclass'. Also, we need to be explicit about the sizing of the fields - because by default it uses native, which most of the time is wrong while doing the cross-compilation on different machines. Byteorder default for RISC-V is little endian. It might be considered to be read from the elf and choosed dynamically in the future.

Next, the lief library in the latest version is having a bit different API - align the codebase to be able to read the header correctly.

Last but not least, to avoid such problems in the future, freeze the dependencies to exact version. That means we don't end up with such incompatibilities when the dependencies release new versions anymore. Bump of the underlaying packages version should be explicit, only after checking if that works.